### PR TITLE
Initialise ansi color highlighting

### DIFF
--- a/pdbcolor/__init__.py
+++ b/pdbcolor/__init__.py
@@ -236,23 +236,6 @@ class LineNumberFilter(Filter):
                 yield ttype, value
 
 
-class PdbLexer(RegexLexer):
-    name = "Pdb"
-    alias = ["pdb"]
-    filenames = ["*"]
-
-    tokens = {
-        "root": [
-            (r"\(Pdb\)", Generic.Subheading),
-            (r"->", Generic.Subheading),
-            (r">>", Generic.Subheading),
-            (r">", Generic.Subheading),
-            (r"B", Generic.Subheading),
-            (r"\[EOF\]", Name.Function),
-        ]
-    }
-
-
 class PathLexer(RegexLexer):
     name = "Path"
     alias = ["path"]

--- a/pdbcolor/__init__.py
+++ b/pdbcolor/__init__.py
@@ -7,9 +7,8 @@ from pygments import highlight
 from pygments.lexers import PythonLexer
 from pygments.lexer import RegexLexer
 from pygments.formatters import TerminalFormatter
-from pygments.token import Operator, Literal, Text, Generic, Comment, Name
+from pygments.token import Generic, Comment, Name
 from pygments.formatters.terminal import TERMINAL_COLORS
-from pygments.filter import Filter
 
 
 class PdbColor(Pdb):

--- a/pdbcolor/__init__.py
+++ b/pdbcolor/__init__.py
@@ -191,31 +191,6 @@ class PdbColor(Pdb):
         return s
 
 
-class CurrentLineFilter(Filter):
-    """Class for combining PDB's current line symbol ('->') into one token."""
-
-    def __init__(self, **options):
-        Filter.__init__(self, **options)
-
-    def filter(self, lexer, stream):
-        previous_token_was_subtract = False
-        for ttype, value in stream:
-            if previous_token_was_subtract:
-                if ttype is Operator and value == ">":
-                    # Combine '->' into one token
-                    yield Generic.Subheading, "->"
-                else:
-                    # Yield previous subtract token and current token separately
-                    yield Operator, "-"
-                    yield ttype, value
-                previous_token_was_subtract = False
-            else:
-                if ttype is Operator and value == "-":
-                    previous_token_was_subtract = True
-                else:
-                    yield ttype, value
-
-
 class LineNumberFilter(Filter):
     """Class for converting PDB's line numbers into tokens."""
 

--- a/pdbcolor/__init__.py
+++ b/pdbcolor/__init__.py
@@ -13,6 +13,29 @@ from pygments.filter import Filter
 
 
 class PdbColor(Pdb):
+    _colors = {
+        "black": 30,
+        "red": 31,
+        "green": 32,
+        "yellow": 33,
+        "blue": 34,
+        "purple": 35,
+        "cyan": 36,
+        "white": 37,
+        "Black": 40,
+        "Red": 41,
+        "Green": 42,
+        "Yellow": 43,
+        "Blue": 44,
+        "Purple": 45,
+        "Cyan": 46,
+        "White": 47,
+        "bold": 1,
+        "light": 2,
+        "blink": 5,
+        "invert": 7,
+    }
+
     def __init__(self):
         super().__init__()
         self.colors = TERMINAL_COLORS.copy()
@@ -22,14 +45,16 @@ class PdbColor(Pdb):
         self.path_lexer = PathLexer()
         self.formatter = TerminalFormatter(colorscheme=self.colors)
 
-        self.pdb_lexer = PdbLexer()
-        self.prompt = highlight("(Pdb)", self.pdb_lexer, self.formatter).rstrip() + " "
-        self.breakpoint_char = highlight("B", self.pdb_lexer, self.formatter).rstrip()
-        self.currentline_char = highlight("->", self.pdb_lexer, self.formatter).rstrip()
-        self.prompt_char = highlight(">>", self.pdb_lexer, self.formatter).rstrip()
-        self.line_prefix = f"\n{self.currentline_char} "
-        self.prefix = highlight(">", self.pdb_lexer, self.formatter).rstrip() + " "
-        self.eof = highlight("[EOF]", self.pdb_lexer, self.formatter).rstrip()
+        self.prompt = self._highlight("(Pdb) ", "purple")
+        self.breakpoint_char = self._highlight("B", "red")
+        self.currentline_char = self._highlight("->", "red")
+        self.prompt_char = self._highlight(">>", "purple")
+        self.line_prefix = f"\n{self._highlight('->', 'purple')} "
+        self.prefix = self._highlight(">", "purple") + " "
+        self.eof = self._highlight("[EOF]", "green")
+
+    def _highlight(self, text: str, color: str) -> str:
+        return f"\x1b[{self._colors[color]}m" + text + "\x1b[0m"
 
     def highlight_lines(self, lines: list[str]):
         lines_highlighted = highlight("".join(lines), self.lexer, self.formatter)

--- a/pdbcolor/__init__.py
+++ b/pdbcolor/__init__.py
@@ -191,26 +191,6 @@ class PdbColor(Pdb):
         return s
 
 
-class LineNumberFilter(Filter):
-    """Class for converting PDB's line numbers into tokens."""
-
-    def __init__(self, **options):
-        Filter.__init__(self, **options)
-
-    def filter(self, lexer, stream):
-        previous_token_was_newline = True
-
-        for ttype, value in stream:
-            if ttype is Text.Whitespace and value == "\n":
-                previous_token_was_newline = True
-                yield ttype, value
-            elif previous_token_was_newline and ttype is Literal.Number.Integer:
-                yield Literal.String, value
-                previous_token_was_newline = False
-            else:
-                yield ttype, value
-
-
 class PathLexer(RegexLexer):
     name = "Path"
     alias = ["path"]

--- a/pdbcolor/__init__.py
+++ b/pdbcolor/__init__.py
@@ -72,7 +72,7 @@ class PdbColor(Pdb):
             current_lineno = exc_lineno = -1
         formatted_lines = []
         for lineno, line in enumerate(lines, start):
-            s = str(lineno).rjust(3)
+            s = self._highlight(str(lineno), "yellow").rjust(3)
             if len(s) < 4:
                 s += " "
             if lineno in breaks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",
 ]
-version = "0.2.0"
+version = "0.2.1"
 license = "MIT"
 license-files = ["LICENSE"]
 


### PR DESCRIPTION
Simplify some of the text highlighting by using ansi escape characters rather than pygments.