### PR TITLE
Fix post mortem debugging for python 3.13

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -25,6 +25,14 @@ jobs:
         name: python-package-distributions
         path: dist/
 
+  test:
+    - name: Upgrade pip
+      run: python3 -m pip install --upgrade pip
+    - name: Install dev dependencies
+      run: python3 -m pip install -e '.[dev]'
+    - name: Run unit tests
+      run: python3 -m pytest
+
   publish-to-pypi:
     name: Publish Python distribution to PyPI
     if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
     - name: Install pypa/build
       run: python3 -m pip install build --user
     - name: Build a binary wheel and a source tarball
@@ -34,7 +34,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
     - name: Upgrade pip
       run: python3 -m pip install --upgrade pip
     - name: Install dev dependencies

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -26,6 +26,10 @@ jobs:
         path: dist/
 
   test:
+    runs-on: ubuntu-latest
+    needs:
+    - build
+    steps:
     - name: Upgrade pip
       run: python3 -m pip install --upgrade pip
     - name: Install dev dependencies

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -30,12 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     needs:
     - build
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.13"
+        python-version: ${{ matrix.python-version }}
     - name: Upgrade pip
       run: python3 -m pip install --upgrade pip
     - name: Install dev dependencies

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -30,6 +30,11 @@ jobs:
     needs:
     - build
     steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
     - name: Upgrade pip
       run: python3 -m pip install --upgrade pip
     - name: Install dev dependencies
@@ -41,6 +46,7 @@ jobs:
     name: Publish Python distribution to PyPI
     if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
     needs:
+    - test
     - build
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -26,6 +26,7 @@ jobs:
         path: dist/
 
   test:
+    name: Run unit tests
     runs-on: ubuntu-latest
     needs:
     - build

--- a/pdbcolor/__main__.py
+++ b/pdbcolor/__main__.py
@@ -1,88 +1,16 @@
-def main():
-    import getopt
-    import os
+"""This module serves as the entry point for the pdbcolor package when invoked
+as a script. For example when pdbcolor is invoked as follows:
+
+    python -m pdbcolor main.py
+"""
+
+if __name__ == "__main__":
     import pdb
-    import sys
-    import traceback
 
     from pdbcolor import PdbColor
 
-    opts, args = getopt.getopt(sys.argv[1:], "mhc:", ["help", "command="])
-
-    if not args:
-        print(pdb._usage)
-        sys.exit(2)
-
-    commands = []
-    run_as_module = False
-    for opt, optarg in opts:
-        if opt in ["-h", "--help"]:
-            print(pdb._usage)
-            sys.exit()
-        elif opt in ["-c", "--command"]:
-            commands.append(optarg)
-        elif opt in ["-m"]:
-            run_as_module = True
-
-    mainpyfile = args[0]  # Get script filename
-    if not run_as_module and not os.path.exists(mainpyfile):
-        print("Error:", mainpyfile, "does not exist")
-        sys.exit(1)
-
-    if run_as_module:
-        import runpy
-
-        try:
-            runpy._get_module_details(mainpyfile)
-        except Exception:
-            traceback.print_exc()
-            sys.exit(1)
-
-    sys.argv[:] = args  # Hide "pdb.py" and pdb options from argument list
-
-    if not run_as_module:
-        mainpyfile = os.path.realpath(mainpyfile)
-        # Replace pdb's dir with script's dir in front of module search path.
-        sys.path[0] = os.path.dirname(mainpyfile)
-
-    # Note on saving/restoring sys.argv: it's a good idea when sys.argv was
-    # modified by the script being debugged. It's a bad idea when it was
-    # changed by the user from the command line. There is a "restart" command
-    # which allows explicit specification of command line arguments.
-    pdbcolor = PdbColor()
-    pdbcolor.rcLines.extend(commands)
-    while True:
-        try:
-            if run_as_module:
-                pdbcolor._runmodule(mainpyfile)
-            else:
-                pdbcolor._runscript(mainpyfile)
-            if pdbcolor._user_requested_quit:
-                break
-            print("The program finished and will be restarted")
-        except pdb.Restart:
-            print("Restarting", mainpyfile, "with arguments:")
-            print("\t" + " ".join(sys.argv[1:]))
-        except SystemExit:
-            # In most cases SystemExit does not warrant a post-mortem session.
-            print("The program exited via sys.exit(). Exit status:", end=" ")
-            print(sys.exc_info()[1])
-        except SyntaxError:
-            traceback.print_exc()
-            sys.exit(1)
-        except:  # noqa: E722
-            traceback.print_exc()
-            print("Uncaught exception. Entering post mortem debugging")
-            print("Running 'cont' or 'step' will restart the program")
-            t = sys.exc_info()[2]
-            pdbcolor.interaction(None, t)
-            print(
-                "Post mortem debugger finished. The "
-                + mainpyfile
-                + " will be restarted"
-            )
-
-
-# When invoked as main program, invoke the debugger on a script
-if __name__ == "__main__":
-    main()
+    # The `main` function creates an instance of `pdb.Pdb` and starts the
+    # debugging session. By pointing `pdb.Pdb` to `PdbColor`, we ensure that the
+    # colorized version of the debugger is used.
+    pdb.Pdb = PdbColor
+    pdb.main()

--- a/pdbcolor/tests/test_main.py
+++ b/pdbcolor/tests/test_main.py
@@ -1,0 +1,49 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def script_with_runtime_error(tmp_path: Path) -> Path:
+    file_path = tmp_path / "file_with_runtime_error.py"
+    file_path.write_text("raise RuntimeError('This is a runtime error.')")
+    return file_path
+
+
+def test_missing_file_prints_error_and_exits_1():
+    """Check that invoking the debugger an a non-existent exits with code 1."""
+    output = subprocess.run(
+        [sys.executable, "-m", "pdb", "script_that_does_not_exist.py"],
+        capture_output=True,
+        text=True,
+    )
+    assert output.returncode == 1
+    assert "does not exist" in output.stdout
+
+
+def test_post_mortem_debugging_uses_pdbcolor(script_with_runtime_error: Path):
+    """Check that post-mortem debugging uses pdbcolor and not pdb."""
+    output = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pdbcolor",
+            "-c",
+            "continue",
+            str(script_with_runtime_error),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=5,  # Prevent hanging if the debugger doesn't exit as expected
+    )
+    assert output.returncode == 0
+    assert "This is a runtime error." in output.stdout
+    assert "(Pdb)" in output.stdout
+    assert "Entering post mortem debugging" in output.stdout
+
+    # Check that the output contains ANSI escape codes, which indicates that
+    # colorization is working. This does not check for specific colors to keep
+    # the test resilient to color scheme changes
+    assert "\x1b" in output.stdout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ license-files = ["LICENSE"]
 [project.optional-dependencies]
 dev = [
     "ruff",
-    "pre-commit"
+    "pre-commit",
+    "pytest",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

* Fix post-mortem debugging for python 3.13.
* Add unit tests to check post-mortem debugging works.
* Add job to CI/CD pipeline that runs the unit tests on several versions of python.